### PR TITLE
Fix snapshot freeze and reposition button

### DIFF
--- a/sketch.js
+++ b/sketch.js
@@ -33,7 +33,8 @@ function setup() {
   // Initialize the Image Classifier method with MobileNet and the video as the second argument
   classifier = ml5.imageClassifier('MobileNet', video, modelReady);  
   button = createButton('Take a snapshot');
-  button.position(20, 350);
+  // place the snapshot button below the video display
+  button.position(20, video.height + 20);
   button.mousePressed(snapshot);
 }
 
@@ -102,6 +103,8 @@ function snapshot() {
       fill(0)
       textAlign(CENTER);
       text(output, 180, 250);
+      // resume the continuous video classification loop
+      classifyVideo();
     }
   });
 }


### PR DESCRIPTION
## Summary
- resume classification after taking a snapshot
- place the snapshot button under the video

## Testing
- `node --check sketch.js`

------
https://chatgpt.com/codex/tasks/task_e_6889952d7464832cb952bd09969c5934